### PR TITLE
Address a couple of Python SyntaxWarnings.

### DIFF
--- a/scripts/uncalled
+++ b/scripts/uncalled
@@ -304,9 +304,9 @@ def sim_cmd(args):
 
 #TODO fix
 def list_ports_cmd(args):
-    log_re = re.compile("^([0-9\-]+ [0-9:]+).+ :.+instance_started.+")
-    port_re = re.compile("grpc_port = (\d+)")
-    device_re = re.compile("(device_id|instance) = ([^\s,]+)")
+    log_re = re.compile(r"^([0-9\-]+ [0-9:]+).+ :.+instance_started.+")
+    port_re = re.compile(r"grpc_port = (\d+)")
+    device_re = re.compile(r"(device_id|instance) = ([^\s,]+)")
 
     fnames = os.listdir(args.log_dir)
     log_fnames = list(sorted( (f for f in fnames if f.startswith("mk_manager_svc")) ))

--- a/uncalled/debug.py
+++ b/uncalled/debug.py
@@ -20,7 +20,7 @@ MAX_CHUNK_DEF = 3
 
 #Cigar parsing
 CIG_OPS_STR = "MIDNSHP=X"
-CIG_RE = re.compile("(\d+)(["+CIG_OPS_STR+"])")
+CIG_RE = re.compile(r"(\d+)(["+CIG_OPS_STR+"])")
 CIG_OPS = set(CIG_OPS_STR)
 CIG_INCR_ALL = {'M','=', 'X'}
 CIG_INCR_RD = CIG_INCR_ALL | {'I','S'}


### PR DESCRIPTION
Running uncalled with Python 3.13 raises a couple of syntax warning, reproducible for instance by running the example script:

	$ cd example
	$ ./run_example.sh
	/usr/bin/uncalled:307: SyntaxWarning: invalid escape sequence '\-'
	  log_re = re.compile("^([0-9\-]+ [0-9:]+).+ :.+instance_started.+")
	/usr/bin/uncalled:308: SyntaxWarning: invalid escape sequence '\d'
	  port_re = re.compile("grpc_port = (\d+)")
	/usr/bin/uncalled:309: SyntaxWarning: invalid escape sequence '\s'
	  device_re = re.compile("(device_id|instance) = ([^\s,]+)")
	[…]

In addition, [Debian bug #1087156] reported also another instance of the issue in the debug.py script:

	Setting up uncalled (2.3+ds-2) ...
	/usr/lib/python3/dist-packages/uncalled/debug.py:23: SyntaxWarning: invalid escape sequence '\d'
	  CIG_RE = re.compile("(\d+)(["+CIG_OPS_STR+"])")

This change adjusts strings to become raw strings, in order to spare Python further attempts to interpret backslashed characters as escape sequences that are invalid.

[Debian bug #1087156]: https://bugs.debian.org/1087156